### PR TITLE
내강의실/강의시청 페이지 레이아웃 수정

### DIFF
--- a/src/components/courseEpisode/style.ts
+++ b/src/components/courseEpisode/style.ts
@@ -43,7 +43,7 @@ const useStyles = createStyles((theme, {backgroundImage}: props) => ({
   },
   
   progressBar: {
-    width: "46.111vw",
+    width: "664px",
   },
 
   duration: {

--- a/src/pages/myClassRoom/MyClassRoom.tsx
+++ b/src/pages/myClassRoom/MyClassRoom.tsx
@@ -188,7 +188,7 @@ const VideoListSection = (
             return (
               <div key={video.number} className={classes.video}>
                 <CourseEpisode
-                  episodeThumbnail={{width: 168, height: 105.8, image: require("../../static/image/myClassRoom/episodeThumbnail.png")}}
+                  episodeThumbnail={{width: 168, height: 95, image: require("../../static/image/myClassRoom/episodeThumbnail.png")}}
                   playImage={{width: 45, height: 45, image: require("../../static/image/myClassRoom/play.png")}}
                   title={"SEASON" + video.seasonNumber}
                   subTitle={video.title}

--- a/src/pages/myClassRoom/style.ts
+++ b/src/pages/myClassRoom/style.ts
@@ -2,10 +2,12 @@ import { createStyles } from '@mantine/core';
 
 const useStyles = createStyles((theme) => ({
   main: {
-    marginTop: "106px",
-    marginBottom: "106px",
-    paddingLeft: "9.375vw",
-    paddingRight: "9.375vw",
+    // marginTop: "106px",
+    // marginBottom: "106px",
+    width: "1440px",
+    margin: "106px auto",
+    // paddingLeft: "9.375vw",
+    // paddingRight: "9.375vw",
     fontFamily: "NotoSansKR",
     fontStyle: "normal",
 
@@ -17,6 +19,10 @@ const useStyles = createStyles((theme) => ({
   contents: {
     display: "flex",
     flexDirection: "column",
+    // alignItems: "center",
+    justifyContent: "center",
+    width: "1168px",
+    margin: "0 auto",
   },
 
   title: {
@@ -121,7 +127,7 @@ const useStyles = createStyles((theme) => ({
     paddingTop: "33px",
     display: "flex",
     flexDirection: "column",
-    width: "81.111vw",
+    width: "auto",
   },
 
   tableHeader: {
@@ -147,10 +153,10 @@ const useStyles = createStyles((theme) => ({
     display: "flex",
     flexDirection: "column",
     justifyContent: "space-between",
-    width: "32.222vw",
+    width: "464px",
 
     paddingTop: "15px",
-    paddingLeft: "2.5vw",
+    paddingLeft: "36px",
     paddingBottom: "21.17px"
   },
 
@@ -173,7 +179,8 @@ const useStyles = createStyles((theme) => ({
     display: "flex",
     flexDirection: "row",
     columnGap: "51px",
-    paddingBottom: "34px"
+    paddingBottom: "34px",
+    width: "264px",
   },
 
   keyValueTable: {

--- a/src/pages/myClassRoom/style.ts
+++ b/src/pages/myClassRoom/style.ts
@@ -2,12 +2,8 @@ import { createStyles } from '@mantine/core';
 
 const useStyles = createStyles((theme) => ({
   main: {
-    // marginTop: "106px",
-    // marginBottom: "106px",
     width: "1440px",
     margin: "106px auto",
-    // paddingLeft: "9.375vw",
-    // paddingRight: "9.375vw",
     fontFamily: "NotoSansKR",
     fontStyle: "normal",
 
@@ -240,6 +236,7 @@ const useStyles = createStyles((theme) => ({
     flexDirection: "column",
     paddingTop: "18px",
     rowGap: "14px",
+    height: "428px",
   },
 
   video: {

--- a/src/pages/videoRoom/VideoRoom.tsx
+++ b/src/pages/videoRoom/VideoRoom.tsx
@@ -107,6 +107,7 @@ const TableHeaderSection = (
             size={37.78}/>
         </div>
         <div className={classes.progressBar}>
+          {/* TODO: 백엔드에서 내려준 값으로 프로그래스 value 값을 설정한다. */}
           <Progress value={1} size={4} radius={22}/>
         </div>
       </div>
@@ -210,7 +211,7 @@ const VideoRoom = () => {
   const navigate = useNavigate();
   const [login] = useLocalStorage<IUserProfile | null>({ key: "login", defaultValue: null });
   const [videoList, setVideoList] = useState<IVideo[]>([]);
-  const numPaginatedVideo = 4;
+  const numPaginatedVideo = 5;
 
   useEffect(
     () => {

--- a/src/pages/videoRoom/style.ts
+++ b/src/pages/videoRoom/style.ts
@@ -4,8 +4,9 @@ const useStyles = createStyles((theme) => ({
   main: {
     marginTop: "115px",
     marginBottom: "188px",
-    paddingLeft: "9.375vw",
-    paddingRight: "12.500vw",
+    marginLeft: "auto",
+    marginRight: "auto",
+    width: "1440px",
     fontFamily: "NotoSansKR",
     fontStyle: "normal",
   },
@@ -14,6 +15,8 @@ const useStyles = createStyles((theme) => ({
     display: "flex",
     flexDirection: "row",
     columnGap: "32px",
+    width: "1168px",
+    margin: "0 auto"
   },
 
   leftSection: {
@@ -204,8 +207,7 @@ const useStyles = createStyles((theme) => ({
   },
   
   progressBar: {
-    maxWidth: "628px",
-    width: "43.611vw",
+    width: "629.6px",
   },
   
   progressText: {
@@ -225,6 +227,7 @@ const useStyles = createStyles((theme) => ({
     flexDirection: "column",
     paddingTop: "0",
     rowGap: "10px",
+    height: "400px",
   },
   
   courseEpisode: {
@@ -244,8 +247,7 @@ const useStyles = createStyles((theme) => ({
     },
 
     "& > div > div > div:nth-of-type(3)": {
-      maxWidth: "628px",
-      width: "43.611vw"
+      width: "629.6px"
     },
 
     "& > div > div:nth-of-type(3)": {


### PR DESCRIPTION
### Summary
- 내강의실 및 강의시청 페이지에 대한 디자인 수정 테스크입니다.

### AS-IS
- 내강의실 및 강의시청 페이지의 레이아웃이 화면 가로폭에 따라 변경되어, 전반적인 집중도가 떨어지는 이슈가 있었습니다.
- 일부 컴포넌트만 화면 가로폭에 따라 조정됨에따라 컴포넌트간 레이아웃이 자연스럽지 못한 문제가 있었습니다.

### TO-BE
- 내강의실 및 강의시청 페이지의 전체적인 레이아웃이 중앙에 오도록 수정하였습니다.
- 일부 컴포넌트를 반응형이 아닌 고정형으로 변경하였습니다.
- 